### PR TITLE
Add policy-ci workflow file

### DIFF
--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -2,34 +2,40 @@ name: Chef Policyfile CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
-  kitchen-and-push:
+  kitchen-test:
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
       - name: Install Chef Workstation
         uses: actionshub/chef-install@3.0.0
-        
+
       - name: Run Kitchen Test
         run: kitchen test
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
 
+  generate-and-push:
+    needs: kitchen-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Chef Workstation
+        uses: actionshub/chef-install@3.0.0
+
       - name: Generate Policyfile.lock.json
-        if: success()
-        
         run: chef install
         env:
           CHEF_LICENSE: accept-no-persist
 
-      - name: Write Chef CI key and config
+      - name: Write Chef config
         env:
           CHEF_CI_PEM: ${{ secrets.CHEF_CI_PEM }}
           CICD_PEM: ${{ vars.DEVOPS_CICD_PEM }}
@@ -37,7 +43,6 @@ jobs:
           CHEF_SERVER_ORG_URL: ${{ vars.DEVOPS_CHEF_SERVER_ORG_URL }}
         run: |
           echo "$CHEF_CI_PEM" | tr -d '\r' > "$CICD_PEM"
-          
           cat > .chef_config <<EOF
           chef_server_url   "${CHEF_SERVER_ORG_URL}"
           node_name         "${CICD_USER}"
@@ -45,18 +50,15 @@ jobs:
           EOF
 
       - name: Push Policyfile to dev
-        if: success()
+        run: |
+          echo "Pushing policy lock file to ${CHEF_SERVER_ORG_URL} using .chef_config"
+          chef push dev Policyfile.rb --config .chef_config
         env:
           CHEF_LICENSE: accept-no-persist
           CHEF_SERVER_ORG_URL: ${{ vars.DEVOPS_CHEF_SERVER_ORG_URL }}
           CICD_USER: ${{ vars.DEVOPS_CICD_USER }}
           CICD_PEM: ${{ vars.DEVOPS_CICD_PEM }}
-        run: |
-          echo "Pushing policy lock file to ${CHEF_SERVER_ORG_URL} using .chef_config"
-          chef push dev Policyfile.rb --config .chef_config --debug
 
-      - name: Cleanup sensitive files
+      - name: Cleanup
         if: always()
-        env:
-          CICD_PEM: ${{ vars.DEVOPS_CICD_PEM }}
-        run: rm -f "$CICD_PEM" .chef_config
+        run: rm -f "${{ vars.DEVOPS_CICD_PEM }}" .chef_config

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -1,0 +1,62 @@
+name: Chef Policyfile CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  kitchen-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Chef Workstation
+        uses: actionshub/chef-install@3.0.0
+        
+      - name: Run Kitchen Test
+        run: kitchen test
+        env:
+          CHEF_LICENSE: accept-no-persist
+          KITCHEN_LOCAL_YAML: kitchen.dokken.yml
+
+      - name: Generate Policyfile.lock.json
+        if: success()
+        
+        run: chef install
+        env:
+          CHEF_LICENSE: accept-no-persist
+
+      - name: Write Chef CI key and config
+        env:
+          CHEF_CI_PEM: ${{ secrets.CHEF_CI_PEM }}
+          CICD_PEM: ${{ vars.DEVOPS_CICD_PEM }}
+          CICD_USER: ${{ vars.DEVOPS_CICD_USER }}
+          CHEF_SERVER_ORG_URL: ${{ vars.DEVOPS_CHEF_SERVER_ORG_URL }}
+        run: |
+          echo "$CHEF_CI_PEM" | tr -d '\r' > "$CICD_PEM"
+          
+          cat > .chef_config <<EOF
+          chef_server_url   "${CHEF_SERVER_ORG_URL}"
+          node_name         "${CICD_USER}"
+          client_key        "${CICD_PEM}"
+          EOF
+
+      - name: Push Policyfile to dev
+        if: success()
+        env:
+          CHEF_LICENSE: accept-no-persist
+          CHEF_SERVER_ORG_URL: ${{ vars.DEVOPS_CHEF_SERVER_ORG_URL }}
+          CICD_USER: ${{ vars.DEVOPS_CICD_USER }}
+          CICD_PEM: ${{ vars.DEVOPS_CICD_PEM }}
+        run: |
+          echo "Pushing policy lock file to ${CHEF_SERVER_ORG_URL} using .chef_config"
+          chef push dev Policyfile.rb --config .chef_config --debug
+
+      - name: Cleanup sensitive files
+        if: always()
+        env:
+          CICD_PEM: ${{ vars.DEVOPS_CICD_PEM }}
+        run: rm -f "$CICD_PEM" .chef_config

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -1,18 +1,28 @@
 name: Chef Policyfile CI
 
 on:
-  push:
-    branches: [main]
+  workflow_call:
+    inputs:
+      platform:
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      chef_workstation_version:
+        required: false
+        type: string
+        default: "latest"
 
 jobs:
   kitchen-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.platform }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
       - name: Install Chef Workstation
         uses: actionshub/chef-install@3.0.0
+        with:
+          version: ${{ inputs.chef_workstation_version }}
 
       - name: Run Kitchen Test
         run: kitchen test
@@ -22,13 +32,15 @@ jobs:
 
   generate-and-push:
     needs: kitchen-test
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.platform }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
       - name: Install Chef Workstation
         uses: actionshub/chef-install@3.0.0
+        with:
+          version: ${{ inputs.chef_workstation_version }}
 
       - name: Generate Policyfile.lock.json
         run: chef install

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Push Policyfile to dev
         run: |
           echo "Pushing policy lock file to ${CHEF_SERVER_ORG_URL} using .chef_config"
-          chef push dev Policyfile.rb --config .chef_config
+          chef push dev Policyfile.lock.json --config .chef_config
         env:
           CHEF_LICENSE: accept-no-persist
           CHEF_SERVER_ORG_URL: ${{ vars.DEVOPS_CHEF_SERVER_ORG_URL }}


### PR DESCRIPTION
This PR adds a new workflow to address [CAMIO-289](https://projects.camio.acep.uaf.edu/cyberinfrastructure/browse/CAMIO-289/) to automate pushing policyfiles to the server. This workflow file will be used by [acep-devops/cookbook-boilerplate](https://github.com/acep-devops/cookbook-boilerplate) repo.


**Question**
- Should I remove the kitchen-test from this workflow and have it in its own workflow file to be reused?
  - It also runs kitchen test within the integration job in [cookbook-boilerplate/.github/workflows/main.yml](https://github.com/acep-devops/cookbook-boilerplate/blob/main/.github/workflows/main.yml)