### PR TITLE
Add reusable kitchen test workflow

### DIFF
--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -1,0 +1,44 @@
+name: Reusable Kitchen Tests
+
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: 'Test Kitchen suites to run'
+        type: string
+        required: false
+        default: 'default'
+      os_list:
+        description: 'JSON string array of OS platforms to add to the Test Kitchen matrix (''["ubuntu-24.04", "ubuntu-22.04"]'').'
+        type: string
+        required: false
+        default: '["ubuntu-24.04"]'
+    secrets:
+      RAILS_MASTER_KEY:
+        required: false
+
+jobs:
+  run-kitchen-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.os_list) }}
+    steps:        
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install Chef
+        uses: actionshub/chef-install@3.0.0
+
+      - name: Debug Versions
+        run: chef -v
+
+      - name: Test Kitchen
+        uses: actionshub/test-kitchen@main
+        with:
+          suite: ${{ inputs.suite }}
+          os: ${{ matrix.os }}
+        env:
+          CHEF_LICENSE: accept-no-persist
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}

--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -9,10 +9,10 @@ on:
         required: false
         default: 'default'
       os_list:
-        description: 'JSON string array of OS platforms to add to the Test Kitchen matrix (''["ubuntu-24.04", "ubuntu-22.04"]'').'
+        description: 'JSON string array of OS platforms to add to the Test Kitchen matrix (''["ubuntu-2404", "ubuntu-2204"]'').'
         type: string
         required: false
-        default: '["ubuntu-24.04"]'
+        default: '["ubuntu-2404"]'
     secrets:
       RAILS_MASTER_KEY:
         required: false


### PR DESCRIPTION
Resolves [RTI-106](https://projects.camio.acep.uaf.edu/cyberinfrastructure/browse/RTI-106/)

Adds a centralized Test Kitchen workflow with a dynamic OS matrix and `RAILS_MASTER_KEY` support.

- Dynamic Matrix: Supports os_list as a JSON string.
- Secrets: Securely passes RAILS_MASTER_KEY for encrypted credentials.
- Defaults:
  - os_list: ubuntu-2404
  - suite: default 
  
[See aedg-server PR:](https://github.com/acep-aedg/aedg-server/pull/58)

 ```yml
     kitchen-test:
        uses: acep-devops/cookbook-ci/.github/workflows/kitchen-tests.yml@main
        secrets: inherit
        with:
            os_list: '["ubuntu-2404"]'
 ```