### PR TITLE
Upgrade github action versions

### DIFF
--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -29,13 +29,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Chef
-        uses: actionshub/chef-install@5.0
+        uses: actionshub/chef-install@5.0.2
 
       - name: Debug Versions
         run: chef -v
 
       - name: Test Kitchen
-        uses: actionshub/test-kitchen@3.0
+        uses: actionshub/test-kitchen@3.0.0
         with:
           suite: ${{ inputs.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -29,13 +29,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Chef
-        uses: actionshub/chef-install@5.0.2
+        uses: actionshub/chef-install@5.0
 
       - name: Debug Versions
         run: chef -v
 
       - name: Test Kitchen
-        uses: actionshub/test-kitchen@3
+        uses: actionshub/test-kitchen@3.0
         with:
           suite: ${{ inputs.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -16,6 +16,8 @@ on:
     secrets:
       RAILS_MASTER_KEY:
         required: false
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   run-kitchen-tests:

--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -35,7 +35,7 @@ jobs:
         run: chef -v
 
       - name: Test Kitchen
-        uses: actionshub/test-kitchen@main
+        uses: actionshub/test-kitchen@3
         with:
           suite: ${{ inputs.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@5.0.2
 
       - name: Debug Versions
         run: chef -v

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@5.0
+        uses: actionshub/chef-install@5.0.2
         with:
           version: ${{ inputs.chef_workstation_version }}
       - name: Install Gems
@@ -49,7 +49,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@5.0
+        uses: actionshub/chef-install@5.0.2
         with:
           version: ${{ inputs.chef_workstation_version }}
       - name: Run Cookstyle

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           CHEF_LICENSE: accept-no-persist
       - name: RSpec Report
-        uses: SonicGarden/rspec-report-action@v6
+        uses: SonicGarden/rspec-report-action@v6.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           json-path: tmp/rspec_results.json

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@5.0.2
         with:
           version: ${{ inputs.chef_workstation_version }}
       - name: Install Gems
@@ -49,7 +49,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@5.0.2
         with:
           version: ${{ inputs.chef_workstation_version }}
       - name: Run Cookstyle

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@5.0.2
+        uses: actionshub/chef-install@5
         with:
           version: ${{ inputs.chef_workstation_version }}
       - name: Install Gems
@@ -37,7 +37,7 @@ jobs:
         env:
           CHEF_LICENSE: accept-no-persist
       - name: RSpec Report
-        uses: SonicGarden/rspec-report-action@v5
+        uses: SonicGarden/rspec-report-action@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           json-path: tmp/rspec_results.json
@@ -49,7 +49,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@5.0.2
+        uses: actionshub/chef-install@5
         with:
           version: ${{ inputs.chef_workstation_version }}
       - name: Run Cookstyle

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ inputs.platform }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Chef
         uses: actionshub/chef-install@3.0.0
         with:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Chef
         uses: actionshub/chef-install@3.0.0
         with:
@@ -61,6 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run yaml Lint
         uses: actionshub/yamllint@main

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@5
+        uses: actionshub/chef-install@5.0
         with:
           version: ${{ inputs.chef_workstation_version }}
       - name: Install Gems
@@ -49,7 +49,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@5
+        uses: actionshub/chef-install@5.0
         with:
           version: ${{ inputs.chef_workstation_version }}
       - name: Run Cookstyle

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -15,6 +15,8 @@ on:
         required: false
         type: string
         default: "latest"
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   rspec:

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Chef Workstation
-        uses: actionshub/chef-install@5.0
+        uses: actionshub/chef-install@5.0.2
         with:
           version: latest
 

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Chef Workstation
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@5.0.2
         with:
           version: latest
 

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Chef Workstation
         uses: actionshub/chef-install@3.0.0

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Chef Workstation
-        uses: actionshub/chef-install@5
+        uses: actionshub/chef-install@5.0
         with:
           version: latest
 

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Chef Workstation
-        uses: actionshub/chef-install@5.0.2
+        uses: actionshub/chef-install@5
         with:
           version: latest
 

--- a/.github/workflows/policyfile-ci.yml
+++ b/.github/workflows/policyfile-ci.yml
@@ -8,6 +8,8 @@ on:
         type: string
         default: "dev"
         description: "The policy group to push to (dev, stage, prod)"
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   push_policy:


### PR DESCRIPTION
- Upgrades `checkout@v4` to `@v6`
- Upgrades `chef-install@3.0.0` to `@5.0.2`
- Changes `kitchen-test@main` to `@3.0.0`
- Upgrades `rspec-report-action@5` to `@v6.0.1`

to fix Node js 20 deprecation warnings:

```sh
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actionshub/chef-install@3.0.0. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

### Tested on aedg-server
Before: https://github.com/acep-aedg/aedg-server/actions/runs/23611013091
After: https://github.com/acep-aedg/aedg-server/actions/runs/23611841580
- 2 warnings still exist for:
  - `SonicGarden/rspec-report-action@v6.0.1`
  - `actionshub/test-kitchen@3.0.0` 
  
I tested forcing nodejs 24 and all tests succeeded. Should I keep or remove the following?
```yml
env:
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
```